### PR TITLE
Fixes a broken api  call for that pulls well known config which controlls Encryption checks

### DIFF
--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -429,20 +429,18 @@ export class AutoDiscovery {
      * be an empty object.
      */
     static async getRawClientConfig(domain) {
+        const lookForWellKnownConfigFromHomeServer = SdkConfig.get()['settingDefaults']['UIFeature.lookForWellKnownConfigFromHomeServer'];
+        console.log("config value for well-known config", lookForWellKnownConfigFromHomeServer);
+        if (lookForWellKnownConfigFromHomeServer) {
+            const default_server_config = SdkConfig.get()['default_server_config'];
+            const base_url_from_config = default_server_config['m.homeserver']['base_url'];
+            console.log("config value for base_url::", base_url_from_config);
+            domain = base_url_from_config.replace('https://', '');
+        }
         if (!domain || typeof(domain) !== "string" || domain.length === 0) {
             throw new Error("'domain' must be a string of non-zero length");
         }
 
-        if (SdkConfig.get()['settingDefaults']['UIFeature.lookForWellKnownConfigFromHomeServer']) {
-            const default_server_config = SdkConfig.get()['default_server_config'];
-            const base_url_from_config = default_server_config['m.homeserver']['base_url'] || SdkConfig.get()['default_server_name'];
-            const server_name = base_url_from_config.replace('https://', '');
-            console.log("config value for base_url::", base_url_from_config);
-            console.log("config value for well-known config", SdkConfig.get()['settingDefaults']['UIFeature.lookForWellKnownConfigFromHomeServer']);
-            if (server_name !== domain) {
-                domain = server_name;
-            }
-        }
         const response = await this._fetchWellKnownObject(
             `https://${domain}/.well-known/matrix/client`,
         );

--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -19,6 +19,7 @@ limitations under the License.
 
 import {logger} from './logger';
 import {URL as NodeURL} from "url";
+import SdkConfig from '../../pegacorn-communicate-matrix-react-sdk/src/SdkConfig';
 
 // Dev note: Auto discovery is part of the spec.
 // See: https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery
@@ -428,13 +429,22 @@ export class AutoDiscovery {
      * be an empty object.
      */
     static async getRawClientConfig(domain) {
+        const default_server_config = SdkConfig.get()['default_server_config'];
+        const base_url_from_config = default_server_config['m.homeserver']['base_url'] || SdkConfig.get()['default_server_name'];
+        const server_name = base_url_from_config.replace('https://','');
+        console.log("config value for base_url:::", base_url_from_config);
+
         if (!domain || typeof(domain) !== "string" || domain.length === 0) {
             throw new Error("'domain' must be a string of non-zero length");
         }
 
+        if(!server_name.includes(domain)){
+            domain = server_name;
+        }
         const response = await this._fetchWellKnownObject(
             `https://${domain}/.well-known/matrix/client`,
         );
+        console.log("E2E well-known response:::", response.raw);
         if (!response) return {};
         return response.raw || {};
     }

--- a/src/autodiscovery.js
+++ b/src/autodiscovery.js
@@ -429,17 +429,19 @@ export class AutoDiscovery {
      * be an empty object.
      */
     static async getRawClientConfig(domain) {
-        const default_server_config = SdkConfig.get()['default_server_config'];
-        const base_url_from_config = default_server_config['m.homeserver']['base_url'] || SdkConfig.get()['default_server_name'];
-        const server_name = base_url_from_config.replace('https://','');
-        console.log("config value for base_url:::", base_url_from_config);
-
         if (!domain || typeof(domain) !== "string" || domain.length === 0) {
             throw new Error("'domain' must be a string of non-zero length");
         }
 
-        if(!server_name.includes(domain)){
-            domain = server_name;
+        if (SdkConfig.get()['settingDefaults']['UIFeature.lookForWellKnownConfigFromHomeServer']) {
+            const default_server_config = SdkConfig.get()['default_server_config'];
+            const base_url_from_config = default_server_config['m.homeserver']['base_url'] || SdkConfig.get()['default_server_name'];
+            const server_name = base_url_from_config.replace('https://', '');
+            console.log("config value for base_url::", base_url_from_config);
+            console.log("config value for well-known config", SdkConfig.get()['settingDefaults']['UIFeature.lookForWellKnownConfigFromHomeServer']);
+            if (server_name !== domain) {
+                domain = server_name;
+            }
         }
         const response = await this._fetchWellKnownObject(
             `https://${domain}/.well-known/matrix/client`,


### PR DESCRIPTION
This merge request swaps domain name to server name that has been configured for app in order to make api call that pulls .well-known configuration from homeserver. Previously, .well-known call assumed domain name is server name.

It is also part of user story for Skin where login prompt asks user "Verify your session with other device?".

User story - 219811

In future it will affect the room's setting as well which has not been further changed in this user story but will be part of User Settings changes outside js-sdk pull request separately.
